### PR TITLE
Updated state variable initialization for StateAgentExecutor and version number

### DIFF
--- a/libs/langchain/src/langchain/agents/agent.py
+++ b/libs/langchain/src/langchain/agents/agent.py
@@ -1206,7 +1206,12 @@ s
         """
         try:
             intermediate_steps = self._prepare_intermediate_steps(intermediate_steps)
-
+            if intermediate_steps:
+                    self.state.append(
+                        {str(intermediate_steps[-1][0]): str(intermediate_steps[-1][1])}
+                    )
+            else:
+                self.state = []
             # Call the LLM to see what to do.
             output = self.agent.plan(
                 intermediate_steps,
@@ -1263,12 +1268,6 @@ s
                 return_direct = tool.return_direct
                 color = color_mapping[agent_action.tool]
                 tool_run_kwargs = self.agent.tool_run_logging_kwargs()
-                if intermediate_steps:
-                    self.state.append(
-                        {str(intermediate_steps[-1][0]): str(intermediate_steps[-1][1])}
-                    )
-                else:
-                    self.state = []
                 # metadata_dict = {}
                 if return_direct:
                     tool_run_kwargs["llm_prefix"] = ""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="spc-langchain",
-    version="0.0.57",
+    version="0.0.58",
     author="Arun raja",
     author_email="arun.raja@skypointcloud.com",
     description="SkyPoint fork of the LangChain library.",


### PR DESCRIPTION
Changes done as part of this PR:
- Since the state variable was initialized before calling AgentAction, the last tool output is not stored in state variable.
- Instead of initializing state variable before calling the AgentAction, now initializing it after intermediate_steps is updated.
- Now this will be passed to AgentFinish also . So that the last tool action is also updated to state